### PR TITLE
Prevent confusion caused by using kilo prefix for 1024

### DIFF
--- a/FSDigitaltechnik.tex
+++ b/FSDigitaltechnik.tex
@@ -206,7 +206,7 @@ $\Omega $ & $ V A^{-1} $\\
 $ H $ & $ V s  A^{-1}$
 \end{tabular}
 \end{multicols}
-$Bit \xrightarrow{\cdot 8} Byte \xrightarrow{\cdot 1024} kByte \xrightarrow{\cdot 1024} MByte$	
+$Bit \xrightarrow{\cdot 8} Byte \xrightarrow{\cdot 1000} kByte \xrightarrow{\cdot 1000} MByte$	
 \section{Boolsche Algebra}
 
 	\subsection{Boolesche Operatoren (Wahrheitstabelle WT)}

--- a/FSDigitaltechnik.tex
+++ b/FSDigitaltechnik.tex
@@ -206,7 +206,8 @@ $\Omega $ & $ V A^{-1} $\\
 $ H $ & $ V s  A^{-1}$
 \end{tabular}
 \end{multicols}
-$Bit \xrightarrow{\cdot 8} Byte \xrightarrow{\cdot 1000} kByte \xrightarrow{\cdot 1000} MByte$	
+$Bit \xrightarrow{\cdot 8} Byte \xrightarrow{\cdot 1000} kByte \xrightarrow{\cdot 1000} MByte$	\\
+$Bit \xrightarrow{\cdot 8} Byte \xrightarrow{\cdot 1024} KiB \xrightarrow{\cdot 1024} MiB$
 \section{Boolsche Algebra}
 
 	\subsection{Boolesche Operatoren (Wahrheitstabelle WT)}


### PR DESCRIPTION
---
name: Vorschlag Fehlerkorrektur
about: Du hast einen Fehler gefunden und willst ihn korrigieren
title: ''
labels: bug
assignees: ''

---

**Fehlerbeschreibung**
kByte sollten 1000 Byte statt 1024 sein, gerade, da direkt über diesem (aus meiner Sicht) Fehler noch "k" als SI-Präfix für 1000 definiert wurde. Unser Dozent redet auch explizit von kiByte falls nötig, meist reichen kByte jedoch aus.

**Referenz**
<img width="696" height="58" alt="kbyte" src="https://github.com/user-attachments/assets/0f0de183-78e1-4197-8cf4-7c15add2408d" />
